### PR TITLE
Fix overflow error when setting width + Don't show subtitle when title is null + Fix Background Color of unselected item and setted it to Colors.transparent

### DIFF
--- a/lib/src/floating_navbar.dart
+++ b/lib/src/floating_navbar.dart
@@ -126,7 +126,7 @@ ItemBuilder _defaultItemBuilder({
               decoration: BoxDecoration(
                   color: currentIndex == items!.indexOf(item)
                       ? selectedBackgroundColor
-                      : backgroundColor,
+                      : Colors.transparent,
                   borderRadius: BorderRadius.circular(itemBorderRadius!)),
               child: InkWell(
                 onTap: () {
@@ -134,8 +134,11 @@ ItemBuilder _defaultItemBuilder({
                 },
                 borderRadius: BorderRadius.circular(8),
                 child: Container(
-                  width: width.isFinite ? (width / items.length - 8) : MediaQuery.of(context).size.width / items.length - 24,
-                  padding: EdgeInsets.symmetric(horizontal: 4, vertical: item.title != null ? 4 : 8),
+                  width: width.isFinite
+                      ? (width / items.length - 8)
+                      : MediaQuery.of(context).size.width / items.length - 24,
+                  padding: EdgeInsets.symmetric(
+                      horizontal: 4, vertical: item.title != null ? 4 : 8),
                   child: Column(
                     mainAxisSize: MainAxisSize.max,
                     mainAxisAlignment: MainAxisAlignment.center,
@@ -148,16 +151,17 @@ ItemBuilder _defaultItemBuilder({
                             : unselectedItemColor,
                         size: iconSize,
                       ),
-                      if (item.title != null) Text(
-                        '${item.title}',
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          color: currentIndex == items.indexOf(item)
-                              ? selectedItemColor
-                              : unselectedItemColor,
-                          fontSize: fontSize,
+                      if (item.title != null)
+                        Text(
+                          '${item.title}',
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            color: currentIndex == items.indexOf(item)
+                                ? selectedItemColor
+                                : unselectedItemColor,
+                            fontSize: fontSize,
+                          ),
                         ),
-                      ),
                     ],
                   ),
                 ),

--- a/lib/src/floating_navbar.dart
+++ b/lib/src/floating_navbar.dart
@@ -18,7 +18,7 @@ class FloatingNavbar extends StatefulWidget {
   final ItemBuilder? itemBuilder;
   final EdgeInsetsGeometry? margin;
   final EdgeInsetsGeometry? padding;
-  final double? width;
+  final double width;
   final double? elevation;
 
   FloatingNavbar({
@@ -42,13 +42,14 @@ class FloatingNavbar extends StatefulWidget {
   })  : assert(items!.length > 1),
         assert(items!.length <= 5),
         assert(currentIndex! <= items!.length),
-        assert(width! > 50),
+        assert(width > 50),
         this.itemBuilder = itemBuilder ??
             _defaultItemBuilder(
               unselectedItemColor: unselectedItemColor,
               selectedItemColor: selectedItemColor,
               borderRadius: borderRadius,
               fontSize: fontSize,
+              width: width,
               backgroundColor: backgroundColor,
               currentIndex: currentIndex,
               iconSize: iconSize,
@@ -109,6 +110,7 @@ ItemBuilder _defaultItemBuilder({
   Color? selectedItemColor,
   Color? unselectedItemColor,
   Color? backgroundColor,
+  double width = double.infinity,
   double? fontSize,
   double? iconSize,
   double? itemBorderRadius,
@@ -132,12 +134,8 @@ ItemBuilder _defaultItemBuilder({
                 },
                 borderRadius: BorderRadius.circular(8),
                 child: Container(
-                  //max-width for each item
-                  //24 is the padding from left and right
-                  width: MediaQuery.of(context).size.width *
-                          (100 / (items.length * 100)) -
-                      24,
-                  padding: EdgeInsets.all(4),
+                  width: width.isFinite ? (width / items.length - 8) : MediaQuery.of(context).size.width / items.length - 24,
+                  padding: EdgeInsets.symmetric(horizontal: 4, vertical: item.title != null ? 4 : 8),
                   child: Column(
                     mainAxisSize: MainAxisSize.max,
                     mainAxisAlignment: MainAxisAlignment.center,
@@ -150,8 +148,9 @@ ItemBuilder _defaultItemBuilder({
                             : unselectedItemColor,
                         size: iconSize,
                       ),
-                      Text(
+                      if (item.title != null) Text(
                         '${item.title}',
+                        overflow: TextOverflow.ellipsis,
                         style: TextStyle(
                           color: currentIndex == items.indexOf(item)
                               ? selectedItemColor

--- a/lib/src/floating_navbar.dart
+++ b/lib/src/floating_navbar.dart
@@ -144,13 +144,15 @@ ItemBuilder _defaultItemBuilder({
                     mainAxisAlignment: MainAxisAlignment.center,
                     crossAxisAlignment: CrossAxisAlignment.center,
                     children: <Widget>[
-                      Icon(
-                        item.icon,
-                        color: currentIndex == items.indexOf(item)
-                            ? selectedItemColor
-                            : unselectedItemColor,
-                        size: iconSize,
-                      ),
+                      item.customWidget == null
+                          ? Icon(
+                              item.icon,
+                              color: currentIndex == items.indexOf(item)
+                                  ? selectedItemColor
+                                  : unselectedItemColor,
+                              size: iconSize,
+                            )
+                          : item.customWidget!,
                       if (item.title != null)
                         Text(
                           '${item.title}',

--- a/lib/src/floating_navbar_item.dart
+++ b/lib/src/floating_navbar_item.dart
@@ -6,8 +6,8 @@ class FloatingNavbarItem {
   final Widget? customWidget;
 
   FloatingNavbarItem({
-    @required this.icon,
-    @required this.title,
-    this.customWidget = const SizedBox(),
-  });
+    this.icon,
+    this.title,
+    this.customWidget,
+  }) : assert(icon != null || customWidget != null);
 }


### PR DESCRIPTION
- Fixes Overflow error when setting width
- Don't show title if it is null
- Set default unselected items background color to transparent
- Make customWidget work, it will replace icon if it is not null

![Screenshot_20210527_113932](https://user-images.githubusercontent.com/41370460/119774795-5bfa1580-bee0-11eb-84bf-61eb1f228868.png)

<details>
<summary>View Code</summary>

```dart
FloatingNavbar(
    onTap: (int val) => setState(() =>  _currentIndex = val),
    currentIndex: _currentIndex,
    selectedBackgroundColor: Colors.black,
    backgroundColor: Colors.black,
    selectedItemColor: Colors.white,
    unselectedItemColor: Colors.grey,
    width: 150,
    iconSize: 26,
    items: [
        FloatingNavbarItem(icon: Icons.home, title: null),
        FloatingNavbarItem(icon: Icons.manage_accounts_sharp,  title: null),
    ],
),
```

</details>